### PR TITLE
subscription:prior_notify task fix

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -34,7 +34,8 @@ module Spree
     scope :active, -> { where(enabled: true) }
     scope :not_cancelled, -> { where(cancelled_at: nil) }
     scope :with_appropriate_delivery_time, -> { where("next_occurrence_at <= :current_date", current_date: Time.current) }
-    scope :eligible_for_subscription, -> { unpaused.active.not_cancelled.with_appropriate_delivery_time }
+    scope :processable, -> { unpaused.active.not_cancelled }
+    scope :eligible_for_subscription, -> { processable.with_appropriate_delivery_time }
     scope :with_parent_orders, -> (orders) { where(parent_order: orders) }
 
     with_options allow_blank: true do
@@ -123,7 +124,7 @@ module Spree
       def eligible_for_prior_notification?
         (next_occurrence_at.to_date - Time.current.to_date).round == prior_notification_days_gap
       end
-      
+
       def update_price
         if valid_variant?
           self.price = variant.price

--- a/lib/tasks/order_prior_notification.rake
+++ b/lib/tasks/order_prior_notification.rake
@@ -1,7 +1,7 @@
 namespace :subscription do
   desc "send prior notification for replenishment items"
   task prior_notify: :environment do |t, args|
-    Spree::Subscription.eligible_for_subscription.find_in_batches do |batches|
+    Spree::Subscription.processable.find_in_batches do |batches|
       batches.map(&:send_prior_notification)
     end
   end

--- a/spec/models/spree/subscription_spec.rb
+++ b/spec/models/spree/subscription_spec.rb
@@ -136,6 +136,13 @@ describe Spree::Subscription, type: :model do
       it { expect(Spree::Subscription.not_cancelled).to_not include cancelled_subscription }
     end
 
+    context ".processable" do
+      it { expect(Spree::Subscription.processable).to include active_subscription }
+      it { expect(Spree::Subscription.processable).to_not include disabled_subscription }
+      it { expect(Spree::Subscription.processable).to_not include cancelled_subscription }
+      it { expect(Spree::Subscription.processable).to_not include paused_subscription }
+    end
+
     context ".eligible_for_subscription" do
       it { expect(Spree::Subscription.eligible_for_subscription).to include active_subscription }
       it { expect(Spree::Subscription.eligible_for_subscription).to_not include disabled_subscription }


### PR DESCRIPTION
## Issue
Currently, **subscription:prior_notify** rake task is not functioning properly.
It should send email notification for those subscriptions whose `next_occurrence_at` is greater than `Time.current` by `prior_notification_days_gap`.

## Fix
This task uses `eligible_for_subscription` scope to fetch subscriptions. `eligible_for_subscription` scope uses `with_appropriate_delivery_time` scope internally, which adds the condition `next_occurrence_at < Time.current`.
But as per the requirement, `next_occurrence_at` should **not** be less than `Time.current`.

Hence, this patch removes the `next_occurrence_at < Time.current` condition from this task, to make it work properly.

